### PR TITLE
fix: add missing closing code tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ _unPublished (not recommended):_
 
 ```
 npm install PATH_TO_GENERATED_PACKAGE --save
+```
 ## Sample Code
 
 ```ts


### PR DESCRIPTION
Adds missing closing code tags around the "unPublished" command snippet so that the Sample Code section displays properly